### PR TITLE
Update CacheManager::createCacheKey() to strip plus signs

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -55,7 +55,7 @@ abstract class CacheManager
     {
         $url = "{$uri->getHost()}{$uri->getPath()}";
 
-        return str_replace(['/', '.', '-', '@'],'_',$url);
+        return str_replace(['/', '.', '-', '@', '+'],'_',$url);
     }
 
     /**

--- a/tests/Unit/Cache/CacheManagerTest.php
+++ b/tests/Unit/Cache/CacheManagerTest.php
@@ -9,7 +9,7 @@ class CacheManagerTest extends BaseTestCase
     public function can_generate_a_cache_key_string_from_a_uri()
     {
          $uriFactory = UriFactoryDiscovery::find();
-         $uri = $uriFactory->createUri('https://okta.com/sample/cache-key/test@test.com');
+         $uri = $uriFactory->createUri('https://okta.com/sample/cache-key/test+test@test.com');
          $query = http_build_query(['with'=>'a','query'=>'string']);
 
          $uri = $uri->withQuery($query);
@@ -20,7 +20,7 @@ class CacheManagerTest extends BaseTestCase
 
          $cacheKey = $client->getCacheManager()->createCacheKey($uri);
 
-         $this->assertEquals('okta_com_sample_cache_key_test_test_com', $cacheKey, 'The cache key was not created correctly.');
+         $this->assertEquals('okta_com_sample_cache_key_test_test_test_com', $cacheKey, 'The cache key was not created correctly.');
     }
 
     /** @test */


### PR DESCRIPTION
Using `\Okta\Users\User::get` to retrieve by an email with a plus sign in it yields an error. Plus is a valid (and common?) character in email addresses. This pull request converts fixes this issue.

```
Cache\Adapter\Common\Exception\InvalidArgumentException: Invalid key "dev_440852_oktapreview_com_api_v1_users_rob+okta+admin_robsanchez_com". Valid filenames must match [a-zA-Z0-9_\.! ]. in /Users/robsanchez/Sites/okta/vendor/cache/filesystem-adapter/FilesystemCachePool.php:145
Stack trace:
#0 /Users/robsanchez/Sites/okta/vendor/cache/filesystem-adapter/FilesystemCachePool.php(64): Cache\Adapter\Filesystem\FilesystemCachePool->getFilePath('dev_440852_okta...')
#1 /Users/robsanchez/Sites/okta/vendor/cache/adapter-common/AbstractCachePool.php(133): Cache\Adapter\Filesystem\FilesystemCachePool->fetchObjectFromCache('dev_440852_okta...')
#2 /Users/robsanchez/Sites/okta/vendor/cache/adapter-common/CacheItem.php(245): Cache\Adapter\Common\AbstractCachePool->Cache\Adapter\Common\{closure}()
#3 /Users/robsanchez/Sites/okta/vendor/cache/adapter-common/CacheItem.php(116): Cache\Adapter\Common\CacheItem->initialize()
#4 /Users/robsanchez/Sites/okta/vendor/cache/adapter-common/AbstractCachePool.php(161): Cache\Adapter\Common\CacheItem->isHit()
#5 /Users/robsanchez/Sites/okta/vendor/okta/sdk/src/DataStore/DefaultDataStore.php(261): Cache\Adapter\Common\AbstractCachePool->hasItem('dev_440852_okta...')
#6 /Users/robsanchez/Sites/okta/vendor/okta/sdk/src/DataStore/DefaultDataStore.php(150): Okta\DataStore\DefaultDataStore->executeRequest('GET', Object(GuzzleHttp\Psr7\Uri))
#7 /Users/robsanchez/Sites/okta/vendor/okta/sdk/src/Generated/Users/User.php(59): Okta\DataStore\DefaultDataStore->getResource('rob+okta+admin@...', 'Okta\\Users\\User', '/users')
#8 /Users/robsanchez/Sites/okta/plugins/okta/src/Service.php(99): Okta\Generated\Users\User->get('rob+okta+admin@...')
```