### PR TITLE
Updates dependencies and fixes tests for phpunit update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 examples
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,6 @@ deploy:
     branch: develop
 matrix:
   include:
-  - php: 7.0
-    env: SETUP=lowest
-  - php: 7.0
-    env: SETUP=stable
   - php: 7.1
     env: SETUP=lowest
   - php: 7.1
@@ -57,6 +53,10 @@ matrix:
   - php: 7.2
     env: SETUP=lowest
   - php: 7.2
+    env: SETUP=stable
+  - php: 7.3
+    env: SETUP=lowest
+  - php: 7.3
     env:
     - COVERAGE=true
     - SETUP=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,6 @@ deploy:
     branch: develop
 matrix:
   include:
-  - php: 7.1
-    env: SETUP=lowest
-  - php: 7.1
-    env: SETUP=stable
   - php: 7.2
     env: SETUP=lowest
   - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -10,25 +10,25 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "psr/http-message": "^1.0",
         "php-http/client-common": "^1.1",
         "php-http/httplug": "^1.1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2",
         "php-http/curl-client": "^1.7",
-        "symfony/yaml": "^3.2",
-        "nesbot/carbon": "^1.22",
-        "tightenco/collect": "5.5.33",
+        "symfony/yaml": "^4.3",
+        "nesbot/carbon": "^2.0",
+        "tightenco/collect": "5.8.31",
         "guzzlehttp/psr7": "^1.4",
         "psr/cache": "^1.0",
         "league/flysystem-memory": "^1.0",
         "cache/filesystem-adapter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "3.*",
-        "symfony/var-dumper": "^3.2",
+        "symfony/var-dumper": "^4.3",
         "php-http/mock-client": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "psr/http-message": "^1.0",
         "php-http/client-common": "^1.1",
         "php-http/httplug": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ca56a073107944d5b32aa50c357e587",
+    "content-hash": "82c621ced8fb763a5a56151e2f0fe0cb",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -3282,7 +3282,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f4928e0583c190e47d4f298330e14a6",
+    "content-hash": "6ca56a073107944d5b32aa50c357e587",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -192,16 +192,16 @@
         },
         {
             "name": "clue/stream-filter",
-            "version": "v1.4.0",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-stream-filter.git",
-                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0"
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
-                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
+                "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
                 "shasum": ""
             },
             "require": {
@@ -216,7 +216,7 @@
                     "Clue\\StreamFilter\\": "src/"
                 },
                 "files": [
-                    "src/functions.php"
+                    "src/functions_include.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -240,36 +240,41 @@
                 "stream_filter_append",
                 "stream_filter_register"
             ],
-            "time": "2017-08-18T09:54:01+00:00"
+            "time": "2019-04-09T12:31:48+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -299,38 +304,39 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.45",
+            "version": "1.0.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6"
+                "reference": "08e12b7628f035600634a5e76d95b5eb66cea674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/08e12b7628f035600634a5e76d95b5eb66cea674",
+                "reference": "08e12b7628f035600634a5e76d95b5eb66cea674",
                 "shasum": ""
             },
             "require": {
+                "ext-fileinfo": "*",
                 "php": ">=5.5.9"
             },
             "conflict": {
                 "league/flysystem-sftp": "<1.0.6"
             },
             "require-dev": {
-                "ext-fileinfo": "*",
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^5.7.10"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -389,27 +395,27 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-05-07T08:44:23+00:00"
+            "time": "2019-06-18T20:09:29+00:00"
         },
         {
             "name": "league/flysystem-memory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-memory.git",
-                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2"
+                "reference": "d0e87477c32e29f999b4de05e64c1adcddb51757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
-                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/d0e87477c32e29f999b4de05e64c1adcddb51757",
+                "reference": "d0e87477c32e29f999b4de05e64c1adcddb51757",
                 "shasum": ""
             },
             "require": {
                 "league/flysystem": "~1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.1"
+                "phpunit/phpunit": "^5.7.10"
             },
             "type": "library",
             "extra": {
@@ -429,8 +435,8 @@
             "authors": [
                 {
                     "name": "Chris Leppanen",
-                    "email": "chris.leppanen@gmail.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "chris.leppanen@gmail.com"
                 }
             ],
             "description": "An in-memory adapter for Flysystem.",
@@ -440,30 +446,38 @@
                 "adapter",
                 "memory"
             ],
-            "time": "2016-06-04T03:57:11+00:00"
+            "time": "2019-05-30T21:34:13+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.33.0",
+            "version": "2.22.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "55667c1007a99e82030874b1bb14d24d07108413"
+                "reference": "738fbd8d80b2c5e158fda76c29c2de432fcc6f7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/55667c1007a99e82030874b1bb14d24d07108413",
-                "reference": "55667c1007a99e82030874b1bb14d24d07108413",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/738fbd8d80b2c5e158fda76c29c2de432fcc6f7e",
+                "reference": "738fbd8d80b2c5e158fda76c29c2de432fcc6f7e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/translation": "~2.6 || ~3.0 || ~4.0"
+                "ext-json": "*",
+                "php": "^7.1.8 || ^8.0",
+                "symfony/translation": "^3.4 || ^4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
+                "kylekatarnls/multi-tester": "^1.1",
+                "phpmd/phpmd": "dev-php-7.1-compatibility",
+                "phpstan/phpstan": "^0.11",
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.4"
             },
+            "bin": [
+                "bin/carbon"
+            ],
             "type": "library",
             "extra": {
                 "laravel": {
@@ -474,7 +488,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "": "src/"
+                    "Carbon\\": "src/Carbon/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -486,6 +500,10 @@
                     "name": "Brian Nesbitt",
                     "email": "brian@nesbot.com",
                     "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "http://github.com/kylekatarnls"
                 }
             ],
             "description": "A simple API extension for DateTime.",
@@ -495,20 +513,20 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-08-07T08:39:47+00:00"
+            "time": "2019-08-07T12:36:44+00:00"
         },
         {
             "name": "php-http/client-common",
-            "version": "1.7.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/client-common.git",
-                "reference": "9accb4a082eb06403747c0ffd444112eda41a0fd"
+                "reference": "0e156a12cc3e46f590c73bf57592a2252fc3dc48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/client-common/zipball/9accb4a082eb06403747c0ffd444112eda41a0fd",
-                "reference": "9accb4a082eb06403747c0ffd444112eda41a0fd",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/0e156a12cc3e46f590c73bf57592a2252fc3dc48",
+                "reference": "0e156a12cc3e46f590c73bf57592a2252fc3dc48",
                 "shasum": ""
             },
             "require": {
@@ -530,7 +548,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.9.x-dev"
                 }
             },
             "autoload": {
@@ -556,7 +574,7 @@
                 "http",
                 "httplug"
             ],
-            "time": "2017-11-30T11:06:59+00:00"
+            "time": "2019-02-02T07:03:15+00:00"
         },
         {
             "name": "php-http/curl-client",
@@ -616,26 +634,29 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.4.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33"
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
-                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/e822f86a6983790aa17ab13aa7e69631e86806b6",
+                "reference": "e822f86a6983790aa17ab13aa7e69631e86806b6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^7.1"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0"
             },
             "require-dev": {
-                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
-                "php-http/httplug": "^1.0",
+                "akeneo/phpspec-skip-example-extension": "^4.0",
+                "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0",
-                "phpspec/phpspec": "^2.4",
+                "phpspec/phpspec": "^5.1",
                 "puli/composer-plugin": "1.0.0-beta10"
             },
             "suggest": {
@@ -645,7 +666,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -674,7 +695,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2018-02-06T10:55:24+00:00"
+            "time": "2019-06-30T09:04:27+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -734,21 +755,21 @@
         },
         {
             "name": "php-http/message",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "741f2266a202d59c4ed75436671e1b8e6f475ea3"
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/741f2266a202d59c4ed75436671e1b8e6f475ea3",
-                "reference": "741f2266a202d59c4ed75436671e1b8e6f475ea3",
+                "url": "https://api.github.com/repos/php-http/message/zipball/ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
                 "shasum": ""
             },
             "require": {
                 "clue/stream-filter": "^1.4",
-                "php": "^5.4 || ^7.0",
+                "php": "^7.1",
                 "php-http/message-factory": "^1.0.2",
                 "psr/http-message": "^1.0"
             },
@@ -774,7 +795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -802,7 +823,7 @@
                 "message",
                 "psr-7"
             ],
-            "time": "2018-08-15T06:37:30+00:00"
+            "time": "2019-08-05T06:55:08+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -1002,16 +1023,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -1045,7 +1066,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -1096,17 +1117,57 @@
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
-            "name": "symfony/options-resolver",
-            "version": "v4.1.3",
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c"
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/1913f1962477cdbb13df951f8147d5da1fe2412c",
-                "reference": "1913f1962477cdbb13df951f8147d5da1fe2412c",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "40762ead607c8f792ee4516881369ffa553fee6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/40762ead607c8f792ee4516881369ffa553fee6f",
+                "reference": "40762ead607c8f792ee4516881369ffa553fee6f",
                 "shasum": ""
             },
             "require": {
@@ -1115,7 +1176,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1147,20 +1208,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-07-26T08:55:25+00:00"
+            "time": "2019-06-13T11:01:17+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -1172,7 +1233,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1189,12 +1250,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1205,20 +1266,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -1230,7 +1291,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1264,30 +1325,89 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v4.1.3",
+            "name": "symfony/polyfill-php72",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "6fcd1bd44fd6d7181e6ea57a6f4e08a09b29ef65"
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "04ce3335667451138df4307d6a9b61565560199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/6fcd1bd44fd6d7181e6ea57a6f4e08a09b29ef65",
-                "reference": "6fcd1bd44fd6d7181e6ea57a6f4e08a09b29ef65",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
+                "reference": "04ce3335667451138df4307d6a9b61565560199e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "4e3e39cc485304f807622bdc64938e4633396406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/4e3e39cc485304f807622bdc64938e4633396406",
+                "reference": "4e3e39cc485304f807622bdc64938e4633396406",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1.2"
             },
             "conflict": {
                 "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -1295,7 +1415,10 @@
                 "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/http-kernel": "~3.4|~4.0",
                 "symfony/intl": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1.2",
+                "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -1306,7 +1429,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1333,42 +1456,106 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-07-18T10:34:59+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v3.4.14",
+            "name": "symfony/translation-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "f62a394bd3de96f2f5e8f4c7d685035897fb3cb3"
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "cb4b18ad7b92a26e83b65dde940fab78339e6f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f62a394bd3de96f2f5e8f4c7d685035897fb3cb3",
-                "reference": "f62a394bd3de96f2f5e8f4c7d685035897fb3cb3",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/cb4b18ad7b92a26e83b65dde940fab78339e6f3c",
+                "reference": "cb4b18ad7b92a26e83b65dde940fab78339e6f3c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-13T11:15:36+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "e4110b992d2cbe198d7d3b244d079c1c58761d07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e4110b992d2cbe198d7d3b244d079c1c58761d07",
+                "reference": "e4110b992d2cbe198d7d3b244d079c1c58761d07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-intl": "To show region name in time zone dump",
-                "ext-symfony_debug": ""
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1402,24 +1589,24 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-07-26T11:19:56+00:00"
+            "time": "2019-07-27T06:42:46+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.14",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "810af2d35fc72b6cf5c01116806d2b65ccaaf2e2"
+                "reference": "34d29c2acd1ad65688f58452fd48a46bd996d5a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/810af2d35fc72b6cf5c01116806d2b65ccaaf2e2",
-                "reference": "810af2d35fc72b6cf5c01116806d2b65ccaaf2e2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/34d29c2acd1ad65688f58452fd48a46bd996d5a6",
+                "reference": "34d29c2acd1ad65688f58452fd48a46bd996d5a6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -1434,7 +1621,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1461,29 +1648,30 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:19:56+00:00"
+            "time": "2019-07-24T14:47:54+00:00"
         },
         {
             "name": "tightenco/collect",
-            "version": "v5.5.33",
+            "version": "v5.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "a2a3ca1c56aa18948b4e08e90f38fcdee859cc4c"
+                "reference": "957e430c26c51b65c80acc87896023229dc05a21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/a2a3ca1c56aa18948b4e08e90f38fcdee859cc4c",
-                "reference": "a2a3ca1c56aa18948b4e08e90f38fcdee859cc4c",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/957e430c26c51b65c80acc87896023229dc05a21",
+                "reference": "957e430c26c51b65c80acc87896023229dc05a21",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "symfony/var-dumper": "~3.3"
+                "php": "^7.1.3",
+                "symfony/var-dumper": ">=3.4 <5"
             },
             "require-dev": {
-                "mockery/mockery": "~1.0",
-                "phpunit/phpunit": "~6.0"
+                "mockery/mockery": "^1.0",
+                "nesbot/carbon": "^1.26.3",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1510,33 +1698,35 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2018-02-09T02:05:17+00:00"
+            "time": "2019-07-30T19:16:47+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -1561,25 +1751,25 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -1614,26 +1804,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11T23:09:50+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -1654,35 +1844,35 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -1701,42 +1891,42 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "php-http/mock-client",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/mock-client.git",
-                "reference": "28195af1ba69590c9c4a02fab7b2eb1fb0200021"
+                "reference": "d364c4a2847229dd37237d0083887889d3bd8564"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/mock-client/zipball/28195af1ba69590c9c4a02fab7b2eb1fb0200021",
-                "reference": "28195af1ba69590c9c4a02fab7b2eb1fb0200021",
+                "url": "https://api.github.com/repos/php-http/mock-client/zipball/d364c4a2847229dd37237d0083887889d3bd8564",
+                "reference": "d364c4a2847229dd37237d0083887889d3bd8564",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5 || ^7.0",
-                "php-http/client-common": "^1.1",
+                "php-http/client-common": "^1.9 || ^2.0",
                 "php-http/discovery": "^1.0",
-                "php-http/httplug": "^1.0",
+                "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0"
             },
             "provide": {
@@ -1750,7 +1940,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1776,7 +1966,7 @@
                 "mock",
                 "psr7"
             ],
-            "time": "2018-01-08T07:39:39+00:00"
+            "time": "2019-02-21T08:51:08+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1834,16 +2024,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -1881,7 +2071,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1932,16 +2122,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -1962,8 +2152,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1991,44 +2181,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
+                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.1.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2043,8 +2233,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -2054,29 +2244,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2019-07-25T05:31:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2091,8 +2284,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -2101,7 +2294,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2146,28 +2339,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2182,8 +2375,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Utility class for timing",
@@ -2191,33 +2384,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2240,57 +2433,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2019-07-25T05:29:42+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.11",
+            "version": "8.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2"
+                "reference": "c319d08ebd31e137034c84ad7339054709491485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7bab54cb366076023bbf457a2a0d513332cd40f2",
-                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c319d08ebd31e137034c84ad7339054709491485",
+                "reference": "c319d08ebd31e137034c84ad7339054709491485",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.0",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2298,7 +2490,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "8.3-dev"
                 }
             },
             "autoload": {
@@ -2313,8 +2505,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -2324,66 +2516,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-08-07T07:05:35+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2019-08-03T15:41:47+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2432,30 +2565,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2492,32 +2625,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2542,34 +2676,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2594,7 +2734,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2665,23 +2805,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2689,7 +2832,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2712,7 +2855,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2861,25 +3004,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2899,7 +3042,53 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2946,16 +3135,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -2988,25 +3177,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -3033,24 +3222,25 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -3083,7 +3273,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],
@@ -3092,7 +3282,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
 

--- a/src/Resource/AbstractCollection.php
+++ b/src/Resource/AbstractCollection.php
@@ -30,7 +30,7 @@ class AbstractCollection extends Collection
      * @param  mixed  $value
      * @return \Closure
      */
-    protected function operatorForWhere($key, $operator, $value = null)
+    protected function operatorForWhere($key, $operator = null, $value = null)
     {
         if (func_num_args() == 2) {
             $value = $operator;

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -21,7 +21,7 @@ use Okta\ClientBuilder;
 class BaseIntegrationTestCase extends BaseTestCase
 {
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         (new ClientBuilder())->build();
@@ -37,7 +37,7 @@ class BaseIntegrationTestCase extends BaseTestCase
         if( ! $this->isMockingResponses() ) {
             return \Okta\Client::getInstance()->getDataStore()->getHttpClient();
         }
-        
+
         $defaults = [
             'getStatusCode' => 200,
             'getBody' => '{}'

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -22,7 +22,7 @@ class BaseTestCase extends TestCase
 {
     protected $token = 'abc123';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         (new ClientBuilder())->build();
@@ -78,7 +78,7 @@ class BaseTestCase extends TestCase
 
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         \Okta\Client::destroy();

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -26,7 +26,7 @@ class BaseUnitTestCase extends BaseTestCase
     protected $modelType;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->properties = json_decode($this->getModelJson($this->model));

--- a/tests/Integration/UsersTest.php
+++ b/tests/Integration/UsersTest.php
@@ -83,34 +83,34 @@ class UsersTest extends BaseIntegrationTestCase
 
             $this->assertEquals('POST', $requests[0]->getMethod(), 'Did not submit a `POST` request for creating a user.');
             $this->assertEquals('application/json', $requests[0]->getHeader('Content-Type')[0], 'Content-Type was not set to `application/json`.');
-            $this->assertContains('SSWS', $requests[0]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[0]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[0]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[0]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals(194, $requests[0]->getHeader('Content-Length')[0], '`Content-Length` is not what is expected.');
             $this->assertEquals('/api/v1/users', $requests[0]->getUri()->getPath(), 'Creating a user does not submit to correct path.');
             $this->assertEquals('activate=false', $requests[0]->getUri()->getQuery(), 'The query param `activate` was not set to `false`.');
 
             //2: Validate the get by id request
             $this->assertEquals('GET', $requests[1]->getMethod(), 'Did not submit a `GET` request for getting a user by id.');
-            $this->assertContains('SSWS', $requests[1]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[1]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[1]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[1]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId(), $requests[1]->getUri()->getPath(), 'Getting User by ID did not make request to correct path');
 
             //3: Validate the get by login request
             $this->assertEquals('GET', $requests[2]->getMethod(), 'Did not submit a `GET` request for getting a user by login.');
-            $this->assertContains('SSWS', $requests[2]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[2]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[2]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[2]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getProfile()->getLogin(), $requests[2]->getUri()->getPath(), 'Getting User by login did not make request to correct path');
 
             //4: Validate the deactivate request
             $this->assertEquals('POST', $requests[3]->getMethod(), 'Did not submit a `POST` request for deactivating a user.');
-            $this->assertContains('SSWS', $requests[3]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[3]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[3]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[3]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId().'/lifecycle/deactivate', $requests[3]->getUri()->getPath(), 'Deactivating a user did not make request to correct path');
 
             //5: Validate the delete request
             $this->assertEquals('DELETE', $requests[4]->getMethod(), 'Did not submit a `DELETE` request when deleting a user.');
-            $this->assertContains('SSWS', $requests[4]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[4]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[4]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[4]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId(), $requests[4]->getUri()->getPath(), 'Deleting a user did not make request to correct path');
 
             //6: Validate the deleted user request
@@ -184,36 +184,36 @@ class UsersTest extends BaseIntegrationTestCase
 
             $this->assertEquals('POST', $requests[0]->getMethod(), 'Did not submit a `POST` request for creating a user.');
             $this->assertEquals('application/json', $requests[0]->getHeader('Content-Type')[0], 'Content-Type was not set to `application/json`.');
-            $this->assertContains('SSWS', $requests[0]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[0]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[0]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[0]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals(204, $requests[0]->getHeader('Content-Length')[0], '`Content-Length` is not what is expected.');
             $this->assertEquals('/api/v1/users', $requests[0]->getUri()->getPath(), 'Creating a user does not submit to correct path.');
             $this->assertEquals('activate=false', $requests[0]->getUri()->getQuery(), 'The query param `activate` was not set to `false`.');
 
             //2: Activate the User Request
             $this->assertEquals('POST', $requests[1]->getMethod(), 'Did not submit a `POST` request for activating a user.');
-            $this->assertContains('SSWS', $requests[1]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[1]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[1]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[1]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId().'/lifecycle/activate', $requests[1]->getUri()->getPath(), 'Activating a user did not make request to correct path.');
             $this->assertEquals('sendEmail=false', $requests[1]->getUri()->getQuery(), 'Setting sendEmail does not work when activating a user.');
 
             //3: Verify user is activated request
             $this->assertEquals('GET', $requests[2]->getMethod(), 'Did not submit a `GET` request for getting a list of users.');
-            $this->assertContains('SSWS', $requests[2]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[2]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[2]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[2]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users', $requests[2]->getUri()->getPath(), 'Getting users did not make request to correct path.');
             $this->assertEquals('filter=status%20eq%20%22ACTIVE%22', $requests[2]->getUri()->getQuery(), 'Setting filter does not work when getting users.');
 
             //4: Validate the deactivate request
             $this->assertEquals('POST', $requests[3]->getMethod(), 'Did not submit a `POST` request for deactivating a user.');
-            $this->assertContains('SSWS', $requests[3]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[3]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[3]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[3]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId().'/lifecycle/deactivate', $requests[3]->getUri()->getPath(), 'Deactivating a user did not make request to correct path');
 
             //5: Validate the delete request
             $this->assertEquals('DELETE', $requests[4]->getMethod(), 'Did not submit a `DELETE` request when deleting a user.');
-            $this->assertContains('SSWS', $requests[4]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
-            $this->assertContains('okta-sdk-php/', $requests[4]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
+            $this->assertStringContainsStringIgnoringCase('SSWS', $requests[4]->getHeader('Authorization')[0], 'Authorization Header does not contain `SSWS`.');
+            $this->assertStringContainsStringIgnoringCase('okta-sdk-php/', $requests[4]->getHeader('User-Agent')[0], 'User-Agent does not contain `okta-sdk-php`.');
             $this->assertEquals('/api/v1/users/'.$createdUser->getId(), $requests[4]->getUri()->getPath(), 'Deleting a user did not make request to correct path');
 
 

--- a/tests/Unit/ClientBuilderTest.php
+++ b/tests/Unit/ClientBuilderTest.php
@@ -23,15 +23,15 @@ use Symfony\Component\Yaml\Parser;
 
 class ClientBuilderTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         file_put_contents(
             'okta.yaml',
-            '{okta: { client: { token:"defaultToken", orgUrl:"https://default-org.okta.com"}}}');
+            '{okta: { client: { token: "defaultToken", orgUrl: "https://default-org.okta.com"}}}');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         unlink('okta.yaml');
         parent::tearDownAfterClass();
@@ -49,7 +49,7 @@ class ClientBuilderTest extends TestCase
              "Setting the token does not return an instance of " . ClientBuilder::class
          );
     }
-    
+
     /** @test */
     public function it_returns_self_when_setting_the_org_url()
     {
@@ -147,8 +147,8 @@ class ClientBuilderTest extends TestCase
 
         $clientBuilder = new ClientBuilder($parser, 'okta.yaml');
 
-        $this->assertContains('Token: abc123', (string)$clientBuilder);
-        $this->assertContains('OrgUrl: https://example.com', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('Token: abc123', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('OrgUrl: https://example.com', (string)$clientBuilder);
 
         putenv("OKTA_CLIENT_TOKEN={$oldToken}");
         putenv("OKTA_CLIENT_ORGURL={$oldOrgUrl}");
@@ -193,9 +193,9 @@ class ClientBuilderTest extends TestCase
         $clientBuilder->setConfigFileLocation(__FILE__);
         $clientBuilder->build();
 
-        $this->assertContains('Token: abc123', (string)$clientBuilderDefault);
-        $this->assertContains('Token: xyz789', (string)$clientBuilder);
-        $this->assertContains('OrgUrl: https://okta.com', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('Token: abc123', (string)$clientBuilderDefault);
+        $this->assertStringContainsStringIgnoringCase('Token: xyz789', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('OrgUrl: https://okta.com', (string)$clientBuilder);
 
         putenv("OKTA_CLIENT_TOKEN={$oldToken}");
         putenv("OKTA_CLIENT_ORGURL={$oldOrgUrl}");
@@ -221,8 +221,8 @@ class ClientBuilderTest extends TestCase
         $clientBuilder->setOrganizationurl('https://okta.com');
         $clientBuilder->build();
 
-        $this->assertContains('Token: TokenSetByMethod', (string)$clientBuilder);
-        $this->assertContains('OrgUrl: https://okta.com', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('Token: TokenSetByMethod', (string)$clientBuilder);
+        $this->assertStringContainsStringIgnoringCase('OrgUrl: https://okta.com', (string)$clientBuilder);
     }
 
     /** @test */

--- a/tests/Unit/Exceptions/ErrorTest.php
+++ b/tests/Unit/Exceptions/ErrorTest.php
@@ -25,7 +25,7 @@ class ErrorTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/Exceptions/ResourceExceptionTest.php
+++ b/tests/Unit/Exceptions/ResourceExceptionTest.php
@@ -26,7 +26,7 @@ class ResourceExceptionTest extends TestCase
     protected static $testable;
     protected static $testableNull;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -66,25 +66,25 @@ class ResourceExceptionTest extends TestCase
     {
         $this->assertEquals(static::$properties->httpStatus, static::$testable->getHttpStatus());
     }
-    
+
     /** @test */
     public function error_code_is_accessible()
     {
         $this->assertEquals(static::$properties->errorCode, static::$testable->getErrorCode());
     }
-    
+
     /** @test */
     public function error_link_is_accessible()
     {
         $this->assertEquals(static::$properties->errorLink, static::$testable->getErrorLink());
     }
-    
+
     /** @test */
     public function error_id_is_accessible()
     {
         $this->assertEquals(static::$properties->errorId, static::$testable->getErrorId());
     }
-    
+
     /** @test */
     public function error_causes_is_accessible()
     {
@@ -96,6 +96,6 @@ class ResourceExceptionTest extends TestCase
     {
         $this->assertEquals(static::$properties->errorSummary, static::$testable->getErrorSummary());
     }
-    
-                    
+
+
 }

--- a/tests/Unit/GroupRules/GroupRuleActionTest.php
+++ b/tests/Unit/GroupRules/GroupRuleActionTest.php
@@ -25,7 +25,7 @@ class GroupRuleActionTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/GroupRules/GroupRuleConditionsTest.php
+++ b/tests/Unit/GroupRules/GroupRuleConditionsTest.php
@@ -25,7 +25,7 @@ class GroupRuleConditionsTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -103,6 +103,6 @@ class GroupRuleConditionsTest extends TestCase
         $localTestable = static::$testable->getExpression();
         $this->assertEquals($groupRuleExpression, $localTestable);
     }
-    
-        
+
+
 }

--- a/tests/Unit/GroupRules/GroupRuleExpressionTest.php
+++ b/tests/Unit/GroupRules/GroupRuleExpressionTest.php
@@ -25,7 +25,7 @@ class GroupRuleExpressionTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/GroupRules/GroupRuleGroupAssignmentTest.php
+++ b/tests/Unit/GroupRules/GroupRuleGroupAssignmentTest.php
@@ -25,7 +25,7 @@ class GroupRuleGroupAssignmentTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -45,7 +45,7 @@ class GroupRuleGroupAssignmentTest extends TestCase
         }
         self::$testable = new GroupRuleGroupAssignment(NULL, $class);
     }
-    
+
     /** @test */
     public function group_ids_is_accessible()
     {
@@ -64,6 +64,6 @@ class GroupRuleGroupAssignmentTest extends TestCase
         static::assertEquals(['789'], static::$testable->getGroupIds());
     }
 
-    
-    
+
+
 }

--- a/tests/Unit/GroupRules/GroupRuleGroupConditionTest.php
+++ b/tests/Unit/GroupRules/GroupRuleGroupConditionTest.php
@@ -25,7 +25,7 @@ class GroupRuleGroupConditionTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -57,17 +57,17 @@ class GroupRuleGroupConditionTest extends TestCase
         $this->assertTrue(is_array(static::$testable->getExclude()));
         $this->assertCount(1, static::$testable->getExclude());
     }
-    
+
     /** @test */
     public function exclude_is_settable()
     {
         static::$testable->setExclude(['123']);
         static::assertEquals(['123'], static::$testable->getExclude());
-    
+
         static::$testable->exclude = ['456'];
         static::assertEquals(['456'], static::$testable->getExclude());
     }
-    
+
 
     /** @test */
     public function include_is_accessible()
@@ -77,17 +77,17 @@ class GroupRuleGroupConditionTest extends TestCase
         $this->assertTrue(is_array(static::$testable->getInclude()));
         $this->assertCount(1, static::$testable->getInclude());
     }
-    
+
     /** @test */
     public function include_is_settable()
     {
         static::$testable->setInclude(['abc']);
         static::assertEquals(['abc'], static::$testable->getInclude());
-    
+
         static::$testable->include = ['def'];
         static::assertEquals(['def'], static::$testable->getInclude());
     }
-    
+
 
 
 }

--- a/tests/Unit/GroupRules/GroupRulePeopleConditionTest.php
+++ b/tests/Unit/GroupRules/GroupRulePeopleConditionTest.php
@@ -25,7 +25,7 @@ class GroupRulePeopleConditionTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/GroupRules/GroupRuleTest.php
+++ b/tests/Unit/GroupRules/GroupRuleTest.php
@@ -26,7 +26,7 @@ class GroupRuleTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/GroupRules/GroupRuleUserConditionTest.php
+++ b/tests/Unit/GroupRules/GroupRuleUserConditionTest.php
@@ -25,7 +25,7 @@ class GroupRuleUserConditionTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -57,17 +57,17 @@ class GroupRuleUserConditionTest extends TestCase
         $this->assertTrue(is_array(static::$testable->getExclude()));
         $this->assertCount(1, static::$testable->getExclude());
     }
-    
+
     /** @test */
     public function exclude_is_settable()
     {
         static::$testable->setExclude(['123']);
         static::assertEquals(['123'], static::$testable->getExclude());
-    
+
         static::$testable->exclude = ['4564'];
         static::assertEquals(['4564'], static::$testable->getExclude());
     }
-    
+
 
     /** @test */
     public function include_is_accessible()
@@ -83,10 +83,10 @@ class GroupRuleUserConditionTest extends TestCase
     {
         static::$testable->setInclude(['abc']);
         static::assertEquals(['abc'], static::$testable->getInclude());
-    
+
         static::$testable->include = ['def'];
         static::assertEquals(['def'], static::$testable->getInclude());
     }
-    
+
 
 }

--- a/tests/Unit/Groups/GroupTest.php
+++ b/tests/Unit/Groups/GroupTest.php
@@ -26,7 +26,7 @@ class GroupTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -144,7 +144,7 @@ class GroupTest extends TestCase
         $this->assertEquals(static::$properties->_embedded, static::$testable->getEmbedded());
         $this->assertEquals(static::$properties->_embedded, static::$testable->embedded);
     }
-    
+
     /** @test */
     public function last_updated_is_accessible()
     {
@@ -153,14 +153,14 @@ class GroupTest extends TestCase
         $this->assertEquals($ts, static::$testable->getLastUpdated()->timestamp);
         $this->assertEquals($ts, static::$testable->lastUpdated->timestamp);
     }
-    
+
     /** @test */
     public function object_class_is_accessible()
     {
         $this->assertEquals(static::$properties->objectClass, static::$testable->getObjectClass());
         $this->assertEquals(static::$properties->objectClass, static::$testable->objectClass);
     }
-    
+
     /** @test */
     public function last_membership_updated_is_accessible()
     {

--- a/tests/Unit/Resource/AbstractResourceTest.php
+++ b/tests/Unit/Resource/AbstractResourceTest.php
@@ -25,7 +25,7 @@ class AbstractResourceTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -47,7 +47,7 @@ class AbstractResourceTest extends TestCase
         self::$testable = new StubResource(null, static::$properties);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         self::$testable->clearOptions();
     }
@@ -64,8 +64,7 @@ class AbstractResourceTest extends TestCase
     /** @test */
     public function can_cast_a_property()
     {
-        $this->assertInternalType(
-            "int",
+        $this->assertIsInt(
             self::$testable->getProperty('testCast', 'int')
         );
 
@@ -125,7 +124,7 @@ class AbstractResourceTest extends TestCase
         $this->assertEquals(static::$properties->id, static::$testable->getId());
         $this->assertEquals(static::$properties->id, static::$testable->id);
     }
-    
+
     /** @test */
     public function returns_null_for_property_that_doesnt_exist()
     {

--- a/tests/Unit/Users/AppLinkTest.php
+++ b/tests/Unit/Users/AppLinkTest.php
@@ -26,7 +26,7 @@ class AppLinkTest extends TestCase
     /** @var ActivationToken */
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $clientBuilder = (new ClientBuilder())->build();
 
@@ -60,7 +60,7 @@ class AppLinkTest extends TestCase
         $this->assertEquals(static::$properties->id, static::$testable->getId());
         $this->assertEquals(static::$properties->id, static::$testable->id);
     }
-    
+
     /** @test */
     public function label_is_accessible()
     {

--- a/tests/Unit/Users/AuthenticationProviderTest.php
+++ b/tests/Unit/Users/AuthenticationProviderTest.php
@@ -26,7 +26,7 @@ class AuthenticationProviderTest extends TestCase
     /** @var \Okta\Users\AuthenticationProvider */
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $clientBuilder = (new ClientBuilder())->build();
 
@@ -52,35 +52,35 @@ class AuthenticationProviderTest extends TestCase
         $this->assertEquals(static::$properties->type, static::$testable->getType());
         $this->assertEquals(static::$properties->type, static::$testable->type);
     }
-    
+
     /** @test */
     public function type_is_settable()
     {
         static::$testable->setType('type1');
         static::assertEquals('type1', static::$testable->getType());
-    
+
         static::$testable->type = 'type2';
         static::assertEquals('type2', static::$testable->getType());
     }
-    
+
     /** @test */
     public function name_is_accessible()
     {
         $this->assertEquals(static::$properties->name, static::$testable->getName());
         $this->assertEquals(static::$properties->name, static::$testable->name);
     }
-    
+
     /** @test */
     public function name_is_settable()
     {
         static::$testable->setName('name1');
         static::assertEquals('name1', static::$testable->getName());
-    
+
         static::$testable->name = 'name2';
         static::assertEquals('name2', static::$testable->getName());
     }
-    
-    
-    
-    
+
+
+
+
 }

--- a/tests/Unit/Users/ChangePasswordRequestTest.php
+++ b/tests/Unit/Users/ChangePasswordRequestTest.php
@@ -25,7 +25,7 @@ class ChangePasswordRequestTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/Users/ForgotPasswordResponseTest.php
+++ b/tests/Unit/Users/ForgotPasswordResponseTest.php
@@ -25,7 +25,7 @@ class ForgotPasswordResponseTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -39,12 +39,12 @@ class ForgotPasswordResponseTest extends TestCase
 
         self::$testable = new ForgotPasswordResponse(null, static::$properties);
     }
-    
+
     /** @test */
     public function reset_password_url_is_accessible()
     {
         $this->assertEquals(static::$properties->resetPasswordUrl, static::$testable->getResetPasswordUrl());
         $this->assertEquals(static::$properties->resetPasswordUrl, static::$testable->resetPasswordUrl);
     }
-    
+
 }

--- a/tests/Unit/Users/PasswordCredentialTest.php
+++ b/tests/Unit/Users/PasswordCredentialTest.php
@@ -25,7 +25,7 @@ class PasswordCredentialTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -52,10 +52,10 @@ class PasswordCredentialTest extends TestCase
     {
         static::$testable->setValue('789dev');
         static::assertEquals('789dev', static::$testable->getValue());
-    
+
         static::$testable->value = 'developer';
         static::assertEquals('developer', static::$testable->getValue());
     }
-    
+
 
 }

--- a/tests/Unit/Users/RecoveryQuestionCredentialTest.php
+++ b/tests/Unit/Users/RecoveryQuestionCredentialTest.php
@@ -25,7 +25,7 @@ class RecoveryQuestionCredentialTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/Users/ResetPasswordTokenTest.php
+++ b/tests/Unit/Users/ResetPasswordTokenTest.php
@@ -25,7 +25,7 @@ class ResetPasswordTokenTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -39,12 +39,12 @@ class ResetPasswordTokenTest extends TestCase
 
         self::$testable = new ResetPasswordToken(null, static::$properties);
     }
-    
+
     /** @test */
     public function reset_password_url_is_accessible()
     {
         $this->assertEquals(static::$properties->resetPasswordUrl, static::$testable->getResetPasswordUrl());
         $this->assertEquals(static::$properties->resetPasswordUrl, static::$testable->resetPasswordUrl);
     }
-    
+
 }

--- a/tests/Unit/Users/RoleTest.php
+++ b/tests/Unit/Users/RoleTest.php
@@ -26,7 +26,7 @@ class RoleTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/Users/TempPasswordTest.php
+++ b/tests/Unit/Users/TempPasswordTest.php
@@ -25,7 +25,7 @@ class TempPasswordTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -37,10 +37,10 @@ class TempPasswordTest extends TestCase
         }
         ');
 
-        
+
         self::$testable = new TempPassword(null, static::$properties);
     }
-    
+
     /** @test */
     public function temp_password_is_accessible()
     {

--- a/tests/Unit/Users/UserActivationTokenTest.php
+++ b/tests/Unit/Users/UserActivationTokenTest.php
@@ -26,7 +26,7 @@ class UserActivationTokenTest extends TestCase
     /** @var ActivationToken */
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $clientBuilder = (new ClientBuilder())->build();
 
@@ -59,5 +59,5 @@ class UserActivationTokenTest extends TestCase
         $this->assertEquals(static::$properties->activationToken, static::$testable->getActivationToken());
         $this->assertEquals(static::$properties->activationToken, static::$testable->activationToken);
     }
-    
+
 }

--- a/tests/Unit/Users/UserCredentialsTest.php
+++ b/tests/Unit/Users/UserCredentialsTest.php
@@ -25,7 +25,7 @@ class UserCredentialsTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/Unit/Users/UserProfileTest.php
+++ b/tests/Unit/Users/UserProfileTest.php
@@ -25,7 +25,7 @@ class UserProfileTest extends TestCase
 
     protected static $testable;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -53,17 +53,17 @@ class UserProfileTest extends TestCase
         $this->assertEquals(static::$properties->email, static::$testable->getEmail());
         $this->assertEquals(static::$properties->email, static::$testable->email);
     }
-    
+
     /** @test */
     public function email_is_settable()
     {
         static::$testable->setEmail('email@mailinator.com');
         static::assertEquals('email@mailinator.com', static::$testable->getEmail());
-    
+
         static::$testable->email = 'email2@mailinator.com';
         static::assertEquals('email2@mailinator.com', static::$testable->getEmail());
     }
-    
+
 
     /** @test */
     public function login_is_accessible()
@@ -71,17 +71,17 @@ class UserProfileTest extends TestCase
         $this->assertEquals(static::$properties->login, static::$testable->getLogin());
         $this->assertEquals(static::$properties->login, static::$testable->login);
     }
-    
+
     /** @test */
     public function login_is_settable()
     {
         static::$testable->setLogin('login');
         static::assertEquals('login', static::$testable->getLogin());
-    
+
         static::$testable->login = 'username';
         static::assertEquals('username', static::$testable->getLogin());
     }
-    
+
 
     /** @test */
     public function first_name_is_accessible()
@@ -89,34 +89,34 @@ class UserProfileTest extends TestCase
         $this->assertEquals(static::$properties->firstName, static::$testable->getFirstName());
         $this->assertEquals(static::$properties->firstName, static::$testable->firstName);
     }
-    
+
     /** @test */
     public function first_name_is_settable()
     {
         static::$testable->setFirstName('first');
         static::assertEquals('first', static::$testable->getFirstName());
-    
+
         static::$testable->firstName = 'name';
         static::assertEquals('name', static::$testable->getFirstName());
     }
-    
+
     /** @test */
     public function last_name_is_accessible()
     {
         $this->assertEquals(static::$properties->lastName, static::$testable->getLastName());
         $this->assertEquals(static::$properties->lastName, static::$testable->lastName);
     }
-    
+
     /** @test */
     public function last_name_is_settable()
     {
         static::$testable->setLastName('last');
         static::assertEquals('last', static::$testable->getLastName());
-    
+
         static::$testable->lastName = 'name';
         static::assertEquals('name', static::$testable->getLastName());
     }
-    
+
     /** @test */
     public function mobile_phone_is_accessible()
     {
@@ -128,11 +128,11 @@ class UserProfileTest extends TestCase
     {
         static::$testable->setMobilePhone('1234567890');
         static::assertEquals('1234567890', static::$testable->getMobilePhone());
-    
+
         static::$testable->mobilePhone = '0987654321';
         static::assertEquals('0987654321', static::$testable->getMobilePhone());
     }
-    
+
     /** @test */
     public function second_email_is_accessible()
     {
@@ -144,11 +144,11 @@ class UserProfileTest extends TestCase
     {
         static::$testable->setSecondEmail('second@mailinator.com');
         static::assertEquals('second@mailinator.com', static::$testable->getSecondEmail());
-    
+
         static::$testable->secondEmail = 'second2@mailinator.com';
         static::assertEquals('second2@mailinator.com', static::$testable->getSecondEmail());
     }
-    
+
     /** @test */
     public function extra_property_is_accessible()
     {

--- a/tests/Unit/Users/UserTest.php
+++ b/tests/Unit/Users/UserTest.php
@@ -701,7 +701,7 @@ class UserTest extends BaseUnitTestCase
             $request[0]->getUri()->getPath()
         );
     }
-    
+
     /** @test */
     public function a_user_can_request_a_password_change()
     {

--- a/tests/Unit/Utilities/EnumTest.php
+++ b/tests/Unit/Utilities/EnumTest.php
@@ -28,10 +28,10 @@ class EnumTest extends TestCase
 
     /**
      * @test
-     * @expectedException \BadMethodCallException
      */
     public function invalid_values_will_throw_exception()
     {
+        $this->expectException('BadMethodCallException');
          DaysOfWeek::BAD();
     }
 
@@ -135,10 +135,10 @@ class EnumTest extends TestCase
 
     /**
      * @test
-     * @expectedException \BadMethodCallException
      */
     public function will_throw_exception_if_method_does_not_exist_for_enum()
     {
+        $this->expectException('BadMethodCallException');
         $tuesday = DaysOfWeek::TUESDAY();
 
         $this->assertTrue($tuesday->isStartOfWeek());
@@ -171,10 +171,10 @@ class EnumTest extends TestCase
 
     /**
      * @test
-     * @expectedException \UnexpectedValueException
      */
     public function throws_exception_if_created_without_valid_value()
     {
+        $this->expectException('UnexpectedValueException');
         new MultiWordEnum('FOO_BAR');
     }
 
@@ -215,8 +215,6 @@ class MultiWordEnum extends \Okta\Utilities\Enum
  * @method static DaysOfWeek THURSDAY()
  * @method static DaysOfWeek FRIDAY()
  * @method static DaysOfWeek SATURDAY()
- * @method bool isStartOfWeek()
- * @method bool isWorkDay()
  *
  */
 class DaysOfWeek extends \Okta\Utilities\Enum

--- a/tests/Unit/Utilities/UserAgentBuilderTest.php
+++ b/tests/Unit/Utilities/UserAgentBuilderTest.php
@@ -22,10 +22,10 @@ class UserAgentBuilderTest extends TestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_properties_are_not_set()
     {
+        $this->expectException('InvalidArgumentException');
         $userAgent = new UserAgentBuilder;
 
         $userAgent->build();
@@ -33,10 +33,10 @@ class UserAgentBuilderTest extends TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_php_version_is_not_set()
     {
+        $this->expectException('InvalidArgumentException');
         $userAgent = new UserAgentBuilder;
 
         $userAgent->setOsName('testOs')
@@ -46,10 +46,10 @@ class UserAgentBuilderTest extends TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_os_version_is_not_set()
     {
+        $this->expectException('InvalidArgumentException');
         $userAgent = new UserAgentBuilder;
 
         $userAgent->setOsName('testOs')
@@ -59,10 +59,10 @@ class UserAgentBuilderTest extends TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_os_name_is_not_set()
     {
+        $this->expectException('InvalidArgumentException');
         $userAgent = new UserAgentBuilder;
 
         $userAgent->setPhpVersion('testOs')


### PR DESCRIPTION
** Updates
 - Updates travis.yaml to test only php 7.2 - php 7.3
 - Updates required version of to be php 7.2
 - Updates package tightenco/collect to v5.8.31 ( Resolves #63 )
 - Updates package phpunit/phpunit to ^8.0
 - Updates symfony/yaml to ^4.3 (Resolves #62 )
 - Updates symfony/var-dumper to ^4.3 (Resolves #62 )
 - Updates nesbot/carbon to ^2.0 ( Resolves #64 )

** Changes
 - Modifies all tests for `setUp` `setUpBeforeClass` `tearDownAfterClass` to have return type of `void` to fix errors after updating phpunit
 - Modifies `operatorForWhere` to have a default operator of `null` in the collect object as required from update to tightenco/collect
 - changes tests to use assertStringContainsStringIgnoreCase due to update of phpunit and deprecated methods
 - some whitespace changes for cleanup

