### PR TITLE
Support symfony/yaml 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/cache": "^1.0",
         "league/flysystem-memory": "^1.0",
         "cache/filesystem-adapter": "^1.0",
-        "vlucas/phpdotenv": "^4.1",
+        "vlucas/phpdotenv": "^3.3|^4.1",
         "lcobucci/jwt": "^4.0@alpha"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2",
         "php-http/curl-client": "^1.7",
-        "symfony/yaml": "^4.3",
+        "symfony/yaml": "^3.2|^4.3",
         "nesbot/carbon": "^2.0",
         "tightenco/collect": "5.8.31",
         "guzzlehttp/psr7": "^1.4",


### PR DESCRIPTION
This library works with either version. octobercms/rain (October CMS) requires ^3.2 however (breaking changes in 4.0 mean that they can't update yet) so this allows any October CMS user to also use this library.