### PR TITLE
Changing createCacheKey to replace _any_ characters that violate file naming standards

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -55,7 +55,7 @@ abstract class CacheManager
     {
         $url = "{$uri->getHost()}{$uri->getPath()}";
 
-        return str_replace(['/', '.', '-', '@', '+'],'_',$url);
+        return preg_replace('/[^a-zA-Z0-9_\.!]/', '_', $url);
     }
 
     /**


### PR DESCRIPTION
By default this tool uses a cache pool that creates local files for caching. The existing implementation covers PSR-6 requirements, but there are some issues that can occur when using the defaults if some bad characters are in the URI used to form the cache key (which is used as the filename). 

For example, assume an Okta instance of testing.oktapreview.com with a user of `test**7@test.com`. By making a get for that user with this library, the URI will be `testing.oktapreview.com/api/v1/users/test**7@test.com`. Based off of the existing code, this name will get transformed to a cache key of `testing_oktapreview_com_api_v1_users_test**7_test_com` which is an invalid file name.

The change I propose would use the regex for valid filenames by default to create cache keys. Under this setup, the cache key would instead be `testing_oktapreview_com_api_v1_users_test__7_test_com` which would be valid.

_Note: There are still going to be some problems if people include lots of the invalid characters in their usernames because you could have collisions. For example, user of `test**7@test.com` and `test++7@test.com` would both hit the same cache key `testing_oktapreview_com_api_v1_users_test__7_test_com`_