### PR TITLE
Handle cases where posix_getpwuid might return false

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -86,7 +86,11 @@ class ClientBuilder
     public function __construct($yamlParser = null, $defaultFilePath = null)
     {
         if(function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
-            $this->defaultFile = posix_getpwuid(posix_getuid())['dir'] . '/' . $this->defaultFile;
+            $userInfo = posix_getpwuid(posix_getuid());
+
+            if (false !== $userInfo) {
+                $this->defaultFile = posix_getpwuid(posix_getuid())['dir'] . '/' . $this->defaultFile;
+            }
         }
         if (null != $defaultFilePath) {
             $this->defaultFile = $defaultFilePath;

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -89,7 +89,7 @@ class ClientBuilder
             $userInfo = posix_getpwuid(posix_getuid());
 
             if (false !== $userInfo) {
-                $this->defaultFile = posix_getpwuid(posix_getuid())['dir'] . '/' . $this->defaultFile;
+                $this->defaultFile = $userInfo['dir'] . '/' . $this->defaultFile;
             }
         }
         if (null != $defaultFilePath) {


### PR DESCRIPTION
`posix_getpwuid` might return `false` if it fails to get the user data, which is most common in Docker environments.